### PR TITLE
Add assertions to scraper test scripts

### DIFF
--- a/test_amazon_scraper.js
+++ b/test_amazon_scraper.js
@@ -1,4 +1,7 @@
 const { searchAmazon } = require('./src/scraper/amazonScraper');
+const assert = require('assert');
+
+// Simple sanity test for the Amazon scraper using Node's assert module.
 
 async function testScraper() {
     const searchTerm = "cadeira gamer"; // Example search term
@@ -6,6 +9,15 @@ async function testScraper() {
 
     try {
         const offers = await searchAmazon(searchTerm);
+
+        // Basic assertions to validate scraper output structure
+        assert(Array.isArray(offers), 'Result should be an array');
+        offers.forEach((offer, index) => {
+            assert.strictEqual(typeof offer, 'object', `Offer at index ${index} should be an object`);
+            ['name', 'price', 'urlOffer', 'site'].forEach((key) => {
+                assert.ok(Object.prototype.hasOwnProperty.call(offer, key), `Offer at index ${index} missing key: ${key}`);
+            });
+        });
 
         console.log(`[TestScript] Received ${offers.length} offers:`);
         if (offers.length > 0) {
@@ -23,6 +35,8 @@ async function testScraper() {
 
     } catch (error) {
         console.error("[TestScript] An error occurred during the test:", error);
+        // Ensure a non-zero exit code when an assertion or runtime error occurs
+        process.exitCode = 1;
     } finally {
         console.log("[TestScript] Test finished.");
     }

--- a/test_mercadolivre_scraper.js
+++ b/test_mercadolivre_scraper.js
@@ -1,4 +1,7 @@
 const { searchMercadoLivre } = require('./src/scraper/mercadoLivreScraper');
+const assert = require('assert');
+
+// Simple sanity test for the Mercado Livre scraper using Node's assert module.
 
 async function testScraper() {
     const searchTerm = "fone de ouvido bluetooth"; // Example search term
@@ -6,6 +9,15 @@ async function testScraper() {
 
     try {
         const offers = await searchMercadoLivre(searchTerm);
+
+        // Basic assertions to validate scraper output structure
+        assert(Array.isArray(offers), 'Result should be an array');
+        offers.forEach((offer, index) => {
+            assert.strictEqual(typeof offer, 'object', `Offer at index ${index} should be an object`);
+            ['name', 'price', 'urlOffer', 'site'].forEach((key) => {
+                assert.ok(Object.prototype.hasOwnProperty.call(offer, key), `Offer at index ${index} missing key: ${key}`);
+            });
+        });
 
         console.log(`[TestScriptML] Received ${offers.length} offers:`);
         if (offers.length > 0) {
@@ -23,6 +35,8 @@ async function testScraper() {
 
     } catch (error) {
         console.error("[TestScriptML] An error occurred during the test:", error);
+        // Ensure a non-zero exit code when an assertion or runtime error occurs
+        process.exitCode = 1;
     } finally {
         console.log("[TestScriptML] Test finished.");
     }


### PR DESCRIPTION
## Summary
- update test scripts to validate scraper outputs using Node `assert`
- exit with a non-zero code when an assertion fails

## Testing
- `npm install`
- `npx playwright install chromium`
- `node test_amazon_scraper.js`
- `node test_mercadolivre_scraper.js`


------
https://chatgpt.com/codex/tasks/task_e_683f685eae388328bff88d5bb316f7c3