### PR TITLE
Fix typo, update handler and add basic test assertions

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,7 +475,7 @@
                                 <tr>
                                     <th>Item Desejado</th>
                                     <th>Site da Oferta</th>
-                                    <th>Preço Simulado</th>
+                                    <th>Preço</th>
                                     <th>URL Original</th>
                                 </tr>
                             </thead>
@@ -552,7 +552,7 @@
                             </div>
                         </div>
                         <div class="mt-8">
-                            <button type="button" class="btn btn-primary" onclick="salvarConfiguracoesSimulado()">
+                            <button type="button" class="btn btn-primary" onclick="salvarConfiguracoes()">
                                 Salvar Configurações
                             </button>
                         </div>
@@ -964,7 +964,7 @@
                 }
             }
 
-            // Renomeado de salvarConfiguracoesSimulado para salvarConfiguracoes
+            // Função responsável por salvar as configurações informadas
             async function salvarConfiguracoes() {
                 const configsObject = {
                     cep: document.getElementById('configCep').value,
@@ -988,9 +988,8 @@
                     showNotification(`Erro inesperado ao salvar configurações: ${error.message}`, 'error');
                 }
             }
-            // Attach to button - assuming the button's onclick was `salvarConfiguracoesSimulado()`
-            // If the button has an ID, it's better to add event listener in DOMContentLoaded
-            // For now, this function is globally available if HTML calls salvarConfiguracoes()
+            // Garante que o botão "Salvar Configurações" utilize a função acima
+            // Caso exista um ID específico, o ideal é adicionar o listener após o DOMContentLoaded
 
             // --- Inicialização ---
             document.addEventListener('DOMContentLoaded', async () => {
@@ -1012,13 +1011,9 @@
                     });
                 }
 
-                // Add event listener for save config button if it has an ID
-                // Example: document.getElementById('btnSalvarConfig').addEventListener('click', salvarConfiguracoes);
-                // For now, assuming the HTML was <button ... onclick="salvarConfiguracoes()">
-                // The provided HTML for the button is: <button type="button" class="btn btn-primary" onclick="salvarConfiguracoesSimulado()">Salvar Configurações</button>
-                // So, we need to make sure salvarConfiguracoes is global or re-attach.
-                // Making it global for now by not wrapping in an IIFE or being a module.
-                // To be safe, explicitly assign it to the window object if it was not global or re-attach the event listener
+                // Adiciona o evento ao botão de salvar, caso não seja utilizado addEventListener no HTML
+                // Se o botão possuir um ID próprio, prefira usar document.getElementById('btnSalvarConfig').addEventListener('click', salvarConfiguracoes);
+                // Esta atribuição garante que o botão existente use a função atual mesmo quando definido via atributo onclick.
                 const saveConfigBtn = Array.from(document.querySelectorAll('button.btn-primary')).find((btn) =>
                     btn.textContent.includes('Salvar Configurações')
                 );

--- a/test_amazon_scraper.js
+++ b/test_amazon_scraper.js
@@ -1,4 +1,5 @@
 const { searchAmazon } = require('./src/scraper/amazonScraper');
+const assert = require('assert');
 
 async function testScraper() {
     const searchTerm = "cadeira gamer"; // Example search term
@@ -7,6 +8,7 @@ async function testScraper() {
     try {
         const offers = await searchAmazon(searchTerm);
 
+        assert.ok(Array.isArray(offers), 'The scraper should return an array');
         console.log(`[TestScript] Received ${offers.length} offers:`);
         if (offers.length > 0) {
             offers.forEach((offer, index) => {
@@ -16,6 +18,10 @@ async function testScraper() {
                 console.log(`URL: ${offer.urlOffer}`);
                 console.log(`Site: ${offer.site}`);
                 console.log(`Installment: ${offer.detailsParcelamento}`);
+
+                assert.ok(offer.name, 'Offer must contain a name');
+                assert.strictEqual(typeof offer.price, 'number', 'Price must be a number');
+                assert.ok(offer.urlOffer, 'Offer must contain urlOffer');
             });
         } else {
             console.log("[TestScript] No offers found.");

--- a/test_mercadolivre_scraper.js
+++ b/test_mercadolivre_scraper.js
@@ -1,4 +1,5 @@
 const { searchMercadoLivre } = require('./src/scraper/mercadoLivreScraper');
+const assert = require('assert');
 
 async function testScraper() {
     const searchTerm = "fone de ouvido bluetooth"; // Example search term
@@ -7,6 +8,7 @@ async function testScraper() {
     try {
         const offers = await searchMercadoLivre(searchTerm);
 
+        assert.ok(Array.isArray(offers), 'The scraper should return an array');
         console.log(`[TestScriptML] Received ${offers.length} offers:`);
         if (offers.length > 0) {
             offers.forEach((offer, index) => {
@@ -16,6 +18,10 @@ async function testScraper() {
                 console.log(`URL: ${offer.urlOffer}`);
                 console.log(`Site: ${offer.site}`);
                 console.log(`Installment: ${offer.detailsParcelamento}`);
+
+                assert.ok(offer.name, 'Offer must contain a name');
+                assert.strictEqual(typeof offer.price, 'number', 'Price must be a number');
+                assert.ok(offer.urlOffer, 'Offer must contain urlOffer');
             });
         } else {
             console.log("[TestScriptML] No offers found.");


### PR DESCRIPTION
## Summary
- fix table header text on search results
- wire "Salvar Configurações" button to proper function
- refresh outdated comments referencing old handler
- add assertions for scraper tests

## Testing
- `node test_amazon_scraper.js`
- `node test_mercadolivre_scraper.js`


------
https://chatgpt.com/codex/tasks/task_e_68400fd04c188328af27eddda65d0572